### PR TITLE
Fixes processing using parent env value in key order

### DIFF
--- a/target/env.go
+++ b/target/env.go
@@ -96,6 +96,12 @@ func (e *Env) process() error {
 	for _, env := range envs {
 		for k, v := range env {
 			e.config[k] = v
+			if e.parent != nil {
+				// use the parents env here if it exists
+				if eParent, ok := e.parent.Env.config[k]; ok {
+					e.config[k] = eParent
+				}
+			}
 			if !keyIn(k, e.keyOrder) {
 				e.keyOrder = append(e.keyOrder, k)
 			}

--- a/target/env_test.go
+++ b/target/env_test.go
@@ -99,6 +99,33 @@ func TestEnv_processParentFile(t *testing.T) {
 	equals(t, want, got)
 }
 
+func TestEnv_processParentFileProcessEnv(t *testing.T) {
+	writer := &bytes.Buffer{}
+	parentEnv := `
+- APP: parent
+`
+	eParent, err := NewEnv(nil, &RawConfig{Envs: parentEnv}, ParseOSEnvs([]string{}), writer)
+	ok(t, err)
+	f := &File{Env: eParent}
+	childEnv := `
+- APP: bubba
+- SOMEVAR: abc/$APP
+`
+	e, err := NewEnv(f, &RawConfig{Envs: childEnv}, ParseOSEnvs([]string{}), writer)
+	ok(t, err)
+	err = e.process()
+	ok(t, err)
+	c, err := e.Config()
+	ok(t, err)
+
+	got := c["APP"]
+	want := `parent`
+	equals(t, want, got)
+	got = c["SOMEVAR"]
+	want = `abc/parent`
+	equals(t, want, got)
+}
+
 func TestEnv_ProcessEnv(t *testing.T) {
 	writer := &bytes.Buffer{}
 	e, err := NewEnv(nil, &RawConfig{Envs: testNewEnvConfig}, ParseOSEnvs([]string{}), writer)


### PR DESCRIPTION
In this case the parent(ron.yaml) had a value that wasn't being set in other envs, for example

```
# ron.yaml
envs:
  APP: ron
```

```
# other.yaml
envs:
  APP: other
  VAR: $APP
```

The expected envs when running other.yaml are 

APP=ron
VAR=ron

but it wasn't using the $APP from the parent and ended up being

APP=ron
VAR=other