### PR TITLE
Adds remote execution of targets

### DIFF
--- a/commands/bash/completion.go
+++ b/commands/bash/completion.go
@@ -16,26 +16,26 @@ _ron()
 
     case ${COMP_CWORD} in
         1)
-						local cmds=$(ron -list)
+            local cmds=$(ron -list)
             COMPREPLY=($(compgen -W "${cmds}" -- ${cur}))
             ;;
         *)
             case ${sub_cmd} in
                 cmd)
-										local command_opts="-loglevel -restart -wait -watch"
+                    local command_opts="-loglevel -restart -wait -watch"
                     COMPREPLY=($(compgen -W "${replace_opts}" -- ${cur}))
                     ;;
                 replace)
-										local replace_opts="-debug -input -output"
+                    local replace_opts="-debug -input -output"
                     COMPREPLY=($(compgen -W "${command_opts}" -- ${cur}))
                     ;;
                 t | target)
-										local target_opts="-debug -default -envs -list -verbose -yaml"
-										local target_list_opts=$(ron t -list_clean)
+                    local target_opts="-debug -default -envs -list -list_remotes -remotes -verbose -yaml"
+                    local target_list_opts=$(ron t -list_clean)
                     COMPREPLY=($(compgen -W "${target_opts} ${target_list_opts}" -- ${cur}))
                     ;;
                 template)
-										local template_opts="-debug -input -output"
+                    local template_opts="-debug -input -output"
                     COMPREPLY=($(compgen -W "${template_opts}" -- ${cur}))
                     ;;
             esac

--- a/commands/target/target.go
+++ b/commands/target/target.go
@@ -37,12 +37,12 @@ func (c *Command) Run(args []string) (int, error) {
 	var overrideYamlPath string
 	f.StringVar(&overrideYamlPath, "yaml", "", `Path to override yaml file, can be local or http.
 
-	ron contains a default set of remotes, envs and targets that can be inspected with the
+	ron contains a default set of envs and targets that can be inspected with the
 	flag options listed above. Those can also be overidden with another yaml file.
 	If no -default or -yaml is provided and in the current or parent working directory there
 	exists a ron.yaml, then those will be used as the -yaml option.
 
-	The yaml config should contain a list of "remotes" (optional), "envs", and a hash of "targets".
+	The yaml config should contain "remotes" (optional), "envs", and a hash of "targets".
 
 	remotes should be defined as a map with any environment name and a list of server values. It's only
 	necessary to define them once so they could be globally set for example in ~/.ron/remotes.yaml
@@ -63,6 +63,13 @@ func (c *Command) Run(args []string) (int, error) {
 					host: exampleprod.com
 					port: 22
 					user: test
+					proxy_host: bastionserver.com
+					proxy_port: 22
+					proxy_user: bastion_user
+					identity_file: /optional/path/to/identityfile
+
+	If no identity file is provided, the users local ssh agent will be attempted. You can add
+	keys with ssh-add.
 
 	env values prefixed with a +(subject to change) will be executed and set to the os environment
 	prior to target execution.

--- a/commands/target/target.go
+++ b/commands/target/target.go
@@ -37,13 +37,32 @@ func (c *Command) Run(args []string) (int, error) {
 	var overrideYamlPath string
 	f.StringVar(&overrideYamlPath, "yaml", "", `Path to override yaml file, can be local or http.
 
-	ron contains a default set of envs and targets that can be inspected with the
+	ron contains a default set of remotes, envs and targets that can be inspected with the
 	flag options listed above. Those can also be overidden with another yaml file.
 	If no -default or -yaml is provided and in the current or parent working directory there
 	exists a ron.yaml, then those will be used as the -yaml option.
 
-	The yaml config should contain a list of "envs" and a
-	hash of "targets".
+	The yaml config should contain a list of "remotes" (optional), "envs", and a hash of "targets".
+
+	remotes should be defined as a map with any environment name and a list of server values. It's only
+	necessary to define them once so they could be globally set for example in ~/.ron/remotes.yaml
+	You can then reference it with -remote=remotes:some_other_env
+
+		remotes:
+			staging:
+				-
+					host: example1.com
+					port: 22
+					user: test
+				-
+					host: example2.com
+					port: 22
+					user: test
+			some_other_env:
+				-
+					host: exampleprod.com
+					port: 22
+					user: test
 
 	env values prefixed with a +(subject to change) will be executed and set to the os environment
 	prior to target execution.
@@ -70,12 +89,16 @@ func (c *Command) Run(args []string) (int, error) {
 	`)
 	var listEnvs bool
 	f.BoolVar(&listEnvs, "envs", false, "List the initialized environment variables.")
+	var listRemotes bool
+	f.BoolVar(&listRemotes, "list_remotes", false, "List the initialized remotes configurations.")
 	var listTargets bool
 	f.BoolVar(&listTargets, "list", false, "List the available targets.")
 	var listTargetsShort bool
 	f.BoolVar(&listTargetsShort, "l", false, "List the available targets.")
 	var listTargetsClean bool
 	f.BoolVar(&listTargetsClean, "list_clean", false, "List the available targets for bash completion.")
+	var remoteEnv string
+	f.StringVar(&remoteEnv, "remotes", "", "The remote target environment to run the target on.")
 	var verbose bool
 	f.BoolVar(&verbose, "verbose", false, "When used with list be verbose.")
 	var verboseShort bool
@@ -105,7 +128,7 @@ func (c *Command) Run(args []string) (int, error) {
 		os.Chdir(foundConfigDir)
 	}
 	// Create targets
-	targetConfig, err := target.NewConfigs(configs, c.W, c.WErr)
+	targetConfig, err := target.NewConfigs(configs, remoteEnv, c.W, c.WErr)
 	if err != nil {
 		return 1, err
 	}
@@ -119,6 +142,13 @@ func (c *Command) Run(args []string) (int, error) {
 	}
 	if listEnvs {
 		err := targetConfig.ListEnvs()
+		if err != nil {
+			return 1, err
+		}
+		return 0, nil
+	}
+	if listRemotes {
+		err := targetConfig.ListRemotes()
 		if err != nil {
 			return 1, err
 		}

--- a/doc.go
+++ b/doc.go
@@ -148,13 +148,33 @@ target name seperated by colon.
 	  -yaml string
 	    	Path to override yaml file, can be local or http.
 
-		ron contains a default set of envs and targets that can be inspected with the
+		ron contains a default set of remotes, envs and targets that can be inspected with the
 		flag options listed above. Those can also be overidden with another yaml file.
-		If no -default or -yaml is provided and in the current working directory there
+		If no -default or -yaml is provided and in the current or parent working directory there
 		exists a ron.yaml, then those will be used as the -yaml option.
 
-		The yaml config should contain a list of "envs" and a
-		hash of "targets".
+		The yaml config should contain a list of "remotes" (optional), "envs", and a hash of "targets".
+
+		remotes should be defined as a map with any environment name and a list of server values. It's only
+		necessary to define them once so they could be globally set for example in ~/.ron/remotes.yaml
+
+			remotes:
+				staging:
+					-
+						host: example1.com
+						port: 22
+						user: test
+					-
+						host: example2.com
+						port: 22
+						user: test
+				some_other_env:
+					-
+						host: exampleprod.com
+						port: 22
+						user: test
+
+		The yaml config should contain a list of "remotes", "envs" and a hash of "targets".
 
 		env values prefixed with a +(subject to change) will be executed and set to the os environment
 		prior to target execution.

--- a/doc.go
+++ b/doc.go
@@ -148,15 +148,16 @@ target name seperated by colon.
 	  -yaml string
 	    	Path to override yaml file, can be local or http.
 
-		ron contains a default set of remotes, envs and targets that can be inspected with the
+		ron contains a default set of envs and targets that can be inspected with the
 		flag options listed above. Those can also be overidden with another yaml file.
 		If no -default or -yaml is provided and in the current or parent working directory there
 		exists a ron.yaml, then those will be used as the -yaml option.
 
-		The yaml config should contain a list of "remotes" (optional), "envs", and a hash of "targets".
+		The yaml config should contain "remotes" (optional), "envs", and a hash of "targets".
 
 		remotes should be defined as a map with any environment name and a list of server values. It's only
 		necessary to define them once so they could be globally set for example in ~/.ron/remotes.yaml
+		You can then reference it with -remote=remotes:some_other_env
 
 			remotes:
 				staging:
@@ -173,8 +174,13 @@ target name seperated by colon.
 						host: exampleprod.com
 						port: 22
 						user: test
+						proxy_host: bastionserver.com
+						proxy_port: 22
+						proxy_user: bastion_user
+						identity_file: /optional/path/to/identityfile
 
-		The yaml config should contain a list of "remotes", "envs" and a hash of "targets".
+		If no identity file is provided, the users local ssh agent will be attempted. You can add
+		keys with ssh-add.
 
 		env values prefixed with a +(subject to change) will be executed and set to the os environment
 		prior to target execution.

--- a/execute/ssh_client.go
+++ b/execute/ssh_client.go
@@ -1,0 +1,140 @@
+package execute
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	"github.com/upsight/ron/color"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// SSH holds the ssh configuration and io.
+type SSH struct {
+	Config *ssh.ClientConfig
+	Host   string
+	Port   int
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// RunCommand will execute a command using the input environment variables.
+// It will establish a new session on every call.
+func (s *SSH) RunCommand(cmd string, envs map[string]string) error {
+	conn, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", s.Host, s.Port), s.Config)
+	if err != nil {
+		return fmt.Errorf("unable to connect: %s", err)
+	}
+	defer conn.Close()
+
+	session, err := conn.NewSession()
+	if err != nil {
+		return fmt.Errorf("failed to create session: %s", err)
+	}
+	defer session.Close()
+
+	modes := ssh.TerminalModes{
+		ssh.ECHO:          0,     // disable echoing
+		ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
+		ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
+	}
+
+	err = session.RequestPty("xterm", 80, 40, modes)
+	if err != nil {
+		return fmt.Errorf("request for pseudo terminal failed: %s", err)
+	}
+
+	err = s.prepareCommand(session, cmd, envs)
+	if err != nil {
+		return err
+	}
+
+	err = session.Start(cmd)
+	if err != nil {
+		return err
+	}
+	return session.Wait()
+}
+
+func (s *SSH) prepareCommand(session *ssh.Session, cmd string, envs map[string]string) error {
+	for k, v := range envs {
+		if err := session.Setenv(k, v); err != nil {
+			return err
+		}
+	}
+
+	if s.Stdin != nil {
+		stdin, err := session.StdinPipe()
+		if err != nil {
+			return fmt.Errorf("unable to setup stdin for session: %v", err)
+		}
+		go io.Copy(stdin, s.Stdin)
+	}
+
+	if s.Stdout != nil {
+		stdout, err := session.StdoutPipe()
+		if err != nil {
+			return fmt.Errorf("unable to setup stdout for session: %v", err)
+		}
+		scanner := bufio.NewScanner(stdout)
+		go func() {
+			for scanner.Scan() {
+				fmt.Fprintf(s.Stdout, color.Green("%s]")+" %s\n", s.Host, scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				fmt.Fprintln(s.Stderr, err)
+			}
+		}()
+	}
+
+	if s.Stderr != nil {
+		stderr, err := session.StderrPipe()
+		if err != nil {
+			return fmt.Errorf("unable to setup stderr for session: %v", err)
+		}
+		scanner := bufio.NewScanner(stderr)
+		go func() {
+			for scanner.Scan() {
+				fmt.Fprintf(s.Stderr, color.Red("%s]")+" %s\n", s.Host, scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				fmt.Fprintln(s.Stderr, err)
+			}
+		}()
+	}
+	return nil
+}
+
+// NewSSH will initialize a new ssh configuration for use with RunCommand.
+// This assumes an ssh agent is available and the proper keys have been added
+// with ssh-add. You can check added keys with ssh-add -L
+func NewSSH(user, host string, port int, stdin io.Reader, stdout, stderr io.Writer) (*SSH, error) {
+	sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
+	if err != nil {
+		return nil, err
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers),
+		},
+		Timeout: time.Duration(5 * time.Second),
+	}
+
+	s := &SSH{
+		Config: sshConfig,
+		Host:   host,
+		Port:   port,
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+	return s, nil
+}

--- a/execute/ssh_client.go
+++ b/execute/ssh_client.go
@@ -28,10 +28,10 @@ type SSHConfig struct {
 	Host         string `json:"host" yaml:"host"`
 	Port         int    `json:"port" yaml:"port"`
 	User         string `json:"user" yaml:"user"`
-	ProxyHost    string `json:"proxy_host" yaml:"proxy_host"`
-	ProxyPort    int    `json:"proxy_port" yaml:"proxy_port"`
-	ProxyUser    string `json:"proxy_user" yaml:"proxy_user"`
-	IdentityFile string `json:"identity_file" yaml:"identity_file"`
+	ProxyHost    string `json:"proxy_host,omitempty" yaml:"proxy_host,omitempty"`
+	ProxyPort    int    `json:"proxy_port,omitempty" yaml:"proxy_port,omitempty"`
+	ProxyUser    string `json:"proxy_user,omitempty" yaml:"proxy_user,omitempty"`
+	IdentityFile string `json:"identity_file,omitempty" yaml:"identity_file,omitempty"`
 }
 
 // RunCommand will execute a command using the input environment variables.

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,3 +5,4 @@ import:
   subpackages:
   - http2
 - package: gopkg.in/yaml.v2
+- package: golang.org/x/crypto/ssh/agent

--- a/ron.yaml
+++ b/ron.yaml
@@ -6,6 +6,10 @@ remotes:
       host: example2.com
       port: 22
       user: test
+      proxy_host:
+      proxy_port:
+      proxy_user:
+      identity_file:
 envs:
   - APP: ron
   - APP_UNDERSCORE: +echo $APP | tr "-" "_"

--- a/ron.yaml
+++ b/ron.yaml
@@ -1,5 +1,11 @@
 {{$path := "export PATH=$GOPATH/bin:$PATH"}}
 {{$list := "$(go list ./... | grep -v vendor/ | grep -v '_/go')"}}
+remotes:
+  staging:
+    -
+      host: example2.com
+      port: 22
+      user: test
 envs:
   - APP: ron
   - APP_UNDERSCORE: +echo $APP | tr "-" "_"
@@ -14,7 +20,7 @@ envs:
 targets:
   echo:
     cmd: |
-      echo $APP
+      echo $APP $HOME
   prep:
     description: Compile the default yaml asset to a go file.
     cmd: |

--- a/target/config.go
+++ b/target/config.go
@@ -163,6 +163,7 @@ func addRonDirConfigs(wd string, configs *[]*RawConfig) {
 
 // addRonYamlFile will prepend the list of configs with
 // any ron.yaml files that are found along with returning its location.
+// oYamlPath is the path to the override yaml file.
 func addRonYamlFile(oYamlPath string, configs *[]*RawConfig) (string, error) {
 	var err error
 	foundConfigDir := ""
@@ -193,7 +194,7 @@ func addRonYamlFile(oYamlPath string, configs *[]*RawConfig) (string, error) {
 
 // addDefaultYamlFile will add a default config which should always be
 // last in priority. If no path option is given a built in default will
-// be created.
+// be created. dYamlPath is the path to the default yaml file.
 func addDefaultYamlFile(dYamlPath string, configs *[]*RawConfig) {
 	envs, targets, err := BuiltinDefault()
 	dConfig := &RawConfig{

--- a/target/config_test.go
+++ b/target/config_test.go
@@ -131,6 +131,24 @@ func TestLoadConfigFiles(t *testing.T) {
 	}
 }
 
+func TestLoadConfigFileWithRemotes(t *testing.T) {
+	c, err := LoadConfigFile(path.Join(wrkdir, "testdata", "ron.yaml"))
+	ok(t, err)
+	want := `production:
+- host: exampleprod.com
+  port: 22
+  user: test
+staging:
+- host: example1.com
+  port: 22
+  user: test
+- host: example2.com
+  port: 22
+  user: test
+`
+	equals(t, want, c.Remotes)
+}
+
 func TestLoadConfigFile(t *testing.T) {
 	_, err := LoadConfigFile(path.Join(wrkdir, "testdata", "target_test.yaml"))
 	ok(t, err)

--- a/target/configs.go
+++ b/target/configs.go
@@ -9,13 +9,14 @@ import (
 	"strings"
 
 	"github.com/upsight/ron/color"
+	"github.com/upsight/ron/execute"
 	yaml "gopkg.in/yaml.v2"
 )
 
 // Configs is a mapping of filename to target file.
 type Configs struct {
-	RemoteEnv   string        // The remote hosts to run the command on. This is (file):env
-	RemoteHosts []*RemoteHost // a list of remote hosts to execute on.
+	RemoteEnv   string               // The remote hosts to run the command on. This is (file):env
+	RemoteHosts []*execute.SSHConfig // a list of remote hosts to execute on.
 	Files       []*File
 	StdOut      io.Writer
 	StdErr      io.Writer

--- a/target/configs.go
+++ b/target/configs.go
@@ -14,14 +14,16 @@ import (
 
 // Configs is a mapping of filename to target file.
 type Configs struct {
-	Files  []*File
-	StdOut io.Writer
-	StdErr io.Writer
+	RemoteEnv   string        // The remote hosts to run the command on. This is (file):env
+	RemoteHosts []*RemoteHost // a list of remote hosts to execute on.
+	Files       []*File
+	StdOut      io.Writer
+	StdErr      io.Writer
 }
 
 // NewConfigs takes a default set of yaml in config format and then
 // overrides them with a new set of config target replacements.
-func NewConfigs(configs []*RawConfig, stdOut io.Writer, stdErr io.Writer) (*Configs, error) {
+func NewConfigs(configs []*RawConfig, remoteEnv string, stdOut io.Writer, stdErr io.Writer) (*Configs, error) {
 	if stdOut == nil {
 		stdOut = os.Stdout
 	}
@@ -29,10 +31,11 @@ func NewConfigs(configs []*RawConfig, stdOut io.Writer, stdErr io.Writer) (*Conf
 		stdErr = os.Stderr
 	}
 
-	t := &Configs{
-		Files:  []*File{},
-		StdOut: stdOut,
-		StdErr: stdErr,
+	confs := &Configs{
+		RemoteEnv: remoteEnv,
+		Files:     []*File{},
+		StdOut:    stdOut,
+		StdErr:    stdErr,
 	}
 	osEnvs := ParseOSEnvs(os.Environ())
 	// parentFile here is the highest priority ron.yaml file.
@@ -42,6 +45,10 @@ func NewConfigs(configs []*RawConfig, stdOut io.Writer, stdErr io.Writer) (*Conf
 		if err := yaml.Unmarshal([]byte(config.Targets), &targets); err != nil {
 			return nil, err
 		}
+		var remotes Remotes
+		if err := yaml.Unmarshal([]byte(config.Remotes), &remotes); err != nil {
+			return nil, err
+		}
 		// initialize io for each target.
 		for name, target := range targets {
 			target.W = stdOut
@@ -49,13 +56,14 @@ func NewConfigs(configs []*RawConfig, stdOut io.Writer, stdErr io.Writer) (*Conf
 			if target.Name == "" {
 				target.Name = name
 			}
-			target.targetConfigs = t
+			target.targetConfigs = confs
 		}
 
 		f := &File{
 			rawConfig: config,
 			Filepath:  config.Filepath,
 			Targets:   targets,
+			Remotes:   remotes,
 		}
 		for _, t := range targets {
 			t.File = f
@@ -65,12 +73,26 @@ func NewConfigs(configs []*RawConfig, stdOut io.Writer, stdErr io.Writer) (*Conf
 			return nil, err
 		}
 		f.Env = e
-		t.Files = append(t.Files, f)
+		confs.Files = append(confs.Files, f)
 		if strings.HasSuffix(config.Filepath, ConfigFileName) {
 			parentFile = f
 		}
 	}
-	return t, nil
+
+	if remoteEnv != "" {
+		// find any remote hosts if set.
+		filePrefix, env := splitTarget(remoteEnv)
+		for _, tf := range confs.Files {
+			if filePrefix != "" && tf.Basename() != filePrefix {
+				continue
+			}
+			if r, ok := tf.Remotes[env]; ok {
+				confs.RemoteHosts = r
+				break
+			}
+		}
+	}
+	return confs, nil
 }
 
 // List prints out each target and its before and after targets.
@@ -153,7 +175,6 @@ func (tc *Configs) GetEnv(name string) MSS {
 		envs, _ := tf.Env.Config()
 		return envs
 	}
-
 	return nil
 }
 
@@ -164,6 +185,17 @@ func (tc *Configs) ListEnvs() error {
 		tf.Env.List()
 		tc.StdOut.Write([]byte(color.Green("---\n\n")))
 	}
+	return nil
+}
 
+// ListRemotes will print out the list of remote envs set in each file.
+func (tc *Configs) ListRemotes() error {
+	for _, tf := range tc.Files {
+		tc.StdOut.Write([]byte(color.Green(fmt.Sprintf("(%s) %s\n", tf.Basename(), tf.Filepath))))
+		if err := tf.Remotes.List(tc.StdOut); err != nil {
+			tc.StdErr.Write([]byte(color.Red(err.Error())))
+		}
+		tc.StdOut.Write([]byte(color.Green("---\n\n")))
+	}
 	return nil
 }

--- a/target/configs_test.go
+++ b/target/configs_test.go
@@ -72,7 +72,7 @@ func createTestConfigs(t *testing.T, stdOut *bytes.Buffer, stdErr *bytes.Buffer)
 			Envs:     ronTargetConfigFile.EnvsString(),
 			Targets:  ronTargetConfigFile.TargetsString(),
 		},
-	}, stdOut, stdErr)
+	}, "", stdOut, stdErr)
 	ok(t, err)
 	return tc, stdOut, stdErr
 }
@@ -146,7 +146,7 @@ func TestNewConfigsListClean(t *testing.T) {
 
 func TestNewConfigsBadDefault(t *testing.T) {
 	stdOut := &bytes.Buffer{}
-	_, err := NewConfigs([]*RawConfig{&RawConfig{Targets: `:"`}}, stdOut, nil)
+	_, err := NewConfigs([]*RawConfig{&RawConfig{Targets: `:"`}}, "", stdOut, nil)
 
 	if err == nil {
 		t.Fatal("expected err for invalid default config")
@@ -154,7 +154,7 @@ func TestNewConfigsBadDefault(t *testing.T) {
 }
 
 func TestNewConfigsBadNew(t *testing.T) {
-	_, err := NewConfigs([]*RawConfig{&RawConfig{Targets: `:"`}}, nil, nil)
+	_, err := NewConfigs([]*RawConfig{&RawConfig{Targets: `:"`}}, "", nil, nil)
 	if err == nil {
 		t.Fatal("expected err for invalid new config")
 	}

--- a/target/file.go
+++ b/target/file.go
@@ -14,6 +14,8 @@ type File struct {
 	Targets map[string]*Target
 	// Env are the files environment variables.
 	Env *Env
+	// Remotes is a mapping of environment to remote hosts.
+	Remotes Remotes
 }
 
 // Basename will return the Filepath name of file without the extension.

--- a/target/make.go
+++ b/target/make.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/upsight/ron/color"
+	"github.com/upsight/ron/execute"
 )
 
 // MSS is an alias for map[string]string
@@ -36,7 +37,7 @@ func (m *Make) Run(names ...string) error {
 			wg := &sync.WaitGroup{}
 			for _, h := range m.Configs.RemoteHosts {
 				wg.Add(1)
-				go func(host *RemoteHost) {
+				go func(host *execute.SSHConfig) {
 					defer wg.Done()
 					status, out, err := target.RunRemote(host)
 					if status != 0 || err != nil {

--- a/target/remotes.go
+++ b/target/remotes.go
@@ -1,0 +1,28 @@
+package target
+
+import (
+	"io"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+// RemoteHost is an individual host configuration for creating
+// and ssh connection.
+type RemoteHost struct {
+	Host string `json:"host" yaml:"host"`
+	Port int    `json:"port" yaml:"port"`
+	User string `json:"user" yaml:"user"`
+}
+
+// Remotes are the mapping of env to list of remote hosts.
+type Remotes map[string][]*RemoteHost
+
+// List will return a list of all possible remotes defined
+func (r *Remotes) List(w io.Writer) error {
+	out, err := yaml.Marshal(r)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(out)
+	return err
+}

--- a/target/remotes.go
+++ b/target/remotes.go
@@ -3,19 +3,13 @@ package target
 import (
 	"io"
 
+	"github.com/upsight/ron/execute"
+
 	yaml "gopkg.in/yaml.v2"
 )
 
-// RemoteHost is an individual host configuration for creating
-// and ssh connection.
-type RemoteHost struct {
-	Host string `json:"host" yaml:"host"`
-	Port int    `json:"port" yaml:"port"`
-	User string `json:"user" yaml:"user"`
-}
-
 // Remotes are the mapping of env to list of remote hosts.
-type Remotes map[string][]*RemoteHost
+type Remotes map[string][]*execute.SSHConfig
 
 // List will return a list of all possible remotes defined
 func (r *Remotes) List(w io.Writer) error {

--- a/target/target.go
+++ b/target/target.go
@@ -84,8 +84,8 @@ func (t *Target) Run() (int, string, error) {
 
 // RunRemote executes the target on a remote host. It ignores any
 // before and after targets.
-func (t *Target) RunRemote(conf *RemoteHost) (int, string, error) {
-	s, err := execute.NewSSH(conf.User, conf.Host, conf.Port, os.Stdin, t.W, t.WErr)
+func (t *Target) RunRemote(conf *execute.SSHConfig) (int, string, error) {
+	s, err := execute.NewSSH(conf, os.Stdin, t.W, t.WErr)
 	if err != nil {
 		return 1, "", err
 	}

--- a/target/target.go
+++ b/target/target.go
@@ -82,6 +82,18 @@ func (t *Target) Run() (int, string, error) {
 	return 0, "", nil
 }
 
+// RunRemote executes the target on a remote host. It ignores any
+// before and after targets.
+func (t *Target) RunRemote(conf *RemoteHost) (int, string, error) {
+	s, err := execute.NewSSH(conf.User, conf.Host, conf.Port, os.Stdin, t.W, t.WErr)
+	if err != nil {
+		return 1, "", err
+	}
+
+	err = s.RunCommand(t.Cmd, nil)
+	return 0, "", err
+}
+
 // List displays the defined before, after, description and cmd of the target.
 func (t *Target) List(verbose bool, nameWidth int) {
 	if !verbose {

--- a/target/testdata/ron.yaml
+++ b/target/testdata/ron.yaml
@@ -13,6 +13,10 @@ remotes:
       host: exampleprod.com
       port: 22
       user: test
+      proxy_host:
+      proxy_port:
+      proxy_user:
+      identity_file:
 envs:
   - APP: ron.yaml
   - UNAME: plan9

--- a/target/testdata/ron.yaml
+++ b/target/testdata/ron.yaml
@@ -1,3 +1,18 @@
+remotes:
+  staging:
+    -
+      host: example1.com
+      port: 22
+      user: test
+    -
+      host: example2.com
+      port: 22
+      user: test
+  production:
+    -
+      host: exampleprod.com
+      port: 22
+      user: test
 envs:
   - APP: ron.yaml
   - UNAME: plan9


### PR DESCRIPTION
Adding basic ability to execute targets on remote machines.

Start with defining in any config file 
```
# ~/.ron/mything.yaml
remotes:
    staging:
        -
            host: example1.com
            port: 22
            user: test
```

And then reference it along with the target wanted

```
$ ron t -remotes=mything:staging someconfig:echo
```

Currently this does not support setting remote envs or before and after targets