### PR TITLE
Fixes tests when there are ~/.ron/*.yaml files, which could interfere

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ or download from [releases](https://github.com/pkar/ron/releases)
 ### Upgrade
 
 	LATEST_URL=https://github.com/upsight/ron/releases/download/v1.0.1/ron-linux-v1.0.1 ron upgrade
+
+### Testing
+
+	$ ron t go:test
+

--- a/commands/target/target.go
+++ b/commands/target/target.go
@@ -125,7 +125,7 @@ func (c *Command) Run(args []string) (int, error) {
 	// go run cmd/ron/main.go t -default=target/default.yaml -l "b*"
 	// [/var/folders/rs/0jn_2dpn36x53x8tvgvptr740000gn/T/go-build906759632/command-line-arguments/_obj/exe/main t -default=target/default.yaml -l b*]
 
-	configs, foundConfigDir, err := target.LoadConfigFiles(defaultYamlPath, overrideYamlPath)
+	configs, foundConfigDir, err := target.LoadConfigFiles(defaultYamlPath, overrideYamlPath, true)
 	if err != nil {
 		return 1, err
 	}

--- a/target/config_test.go
+++ b/target/config_test.go
@@ -33,7 +33,7 @@ func Test_findConfigDirs(t *testing.T) {
 	ok(t, err)
 	want := filepath.Join(wd, "testdata", ConfigDirName)
 
-	dirs := findConfigDirs(filepath.Join(wd, "testdata"))
+	dirs := findConfigDirs(filepath.Join(wd, "testdata"), false)
 
 	found := false
 	for _, dir := range dirs {
@@ -120,7 +120,7 @@ func TestLoadConfigFiles(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configs, found, err := LoadConfigFiles(tt.defaultYamlPath, tt.overrideYamlPath)
+			configs, found, err := LoadConfigFiles(tt.defaultYamlPath, tt.overrideYamlPath, false)
 			ok(t, err)
 			for i, config := range configs {
 				equals(t, strings.TrimSpace(tt.expectedConfigs[i].Envs), strings.TrimSpace(config.Envs))


### PR DESCRIPTION
This adds an option to not load home directory .yaml files. There was a case where something in my home directory was causing the tests to fail.