### PR TITLE
Changes the behavior of env parent to child

### DIFF
--- a/target/env.go
+++ b/target/env.go
@@ -148,9 +148,12 @@ func (e *Env) process() error {
 		e.config[k] = os.Expand(e.config[k], e.Getenv)
 	}
 	if e.parent != nil {
-		// set the parent envs here as final values.
+		// set the final envs from parent here as final
+		// only if the value is empty.
 		for k, v := range e.parent.Env.config {
-			e.config[k] = v
+			if e.config[k] == "" {
+				e.config[k] = v
+			}
 		}
 	}
 	return nil

--- a/target/env_test.go
+++ b/target/env_test.go
@@ -84,7 +84,7 @@ func TestEnv_processParentFile(t *testing.T) {
 	eParent, err := NewEnv(nil, &RawConfig{Envs: ""}, ParseOSEnvs([]string{"APP=don", "HELLO=goodbye", "ABC=+pwd"}), writer)
 	ok(t, err)
 	f := &File{Env: eParent}
-	e, err := NewEnv(f, &RawConfig{Envs: ""}, ParseOSEnvs([]string{"APP=ron", "HELLO=hello", "ABC=+pwd"}), writer)
+	e, err := NewEnv(f, &RawConfig{Envs: ""}, ParseOSEnvs([]string{"APP=", "HELLO=hello", "ABC=+pwd"}), writer)
 	ok(t, err)
 	err = e.process()
 	ok(t, err)
@@ -95,7 +95,7 @@ func TestEnv_processParentFile(t *testing.T) {
 	want := `don`
 	equals(t, want, got)
 	got = c["HELLO"]
-	want = `goodbye`
+	want = `hello`
 	equals(t, want, got)
 }
 


### PR DESCRIPTION
Previously the parent would overwrite any child set env config like targets do. This works for targets because you can do various things within the target, including call the child, but with envs being a single value it tends to break child yaml files.

For example if in ron.yaml you don't define an env like A, and it's defined somewhere in some other child yaml file, the parent inherits that A, but then if the target is actually some other child and it had that A value specified on purpose, it would get overwritten with the parent A and usually break.

So this basically changes the behavior to only set the final env value if it is empty.